### PR TITLE
New frame rate initialization and frame delimiters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,25 @@
 Changes
 =======
 
+0.4.0
+=====
+
+* **New:** Frame delimiter is now set to ":" for Non Drop Frame, ";" for Drop
+  Frame and "." for millisecond based time codes.
+  If ``Timecode.__init__()`` start_timecode is passed a string with the wrong
+  delimiter it will be converted automatically.
+
+* **Update:** All tests involving Drop Frame and millisecond time codes are now
+  set to use the new delimiter.
+
+* **New:** ``Timecode.tc_to_string()`` method added to present the correctly
+  formatted time code.
+
+* **New:** ``Timecode.ms_frame`` boolean attribute added.
+
+* **New:** ``Timecode.__init__()`` now supports strings, ints and floats for
+  the framerate argument.
+
 0.3.0
 =====
 
@@ -18,7 +37,7 @@ Changes
 
 * **Update:** Timecode.__init__() arguments has been changed, removed the
   unnecessary ``drop_frame``, ``iter_returns`` arguments.
-  
+
   Drop frame can be interpreted from the ``framerate`` argument and
   ``iter_returns`` is unnecessary cause any iteration on the object will return
   another ``Timecode`` instance.

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -27,12 +27,12 @@ class TimecodeTester(unittest.TestCase):
         Timecode('23.98', '00:00:00:00')
         Timecode('24', '00:00:00:00')
         Timecode('25', '00:00:00:00')
-        Timecode('29.97', '00:00:00:00')
+        Timecode('29.97', '00:00:00;00')
         Timecode('30', '00:00:00:00')
         Timecode('50', '00:00:00:00')
-        Timecode('59.94', '00:00:00:00')
+        Timecode('59.94', '00:00:00;00')
         Timecode('60', '00:00:00:00')
-        Timecode('ms', '03:36:09:230')
+        Timecode('ms', '03:36:09.230')
         Timecode('24', start_timecode=None, frames=12000)
 
         Timecode('23.98')
@@ -44,7 +44,29 @@ class TimecodeTester(unittest.TestCase):
         Timecode('59.94')
         Timecode('60')
         Timecode('ms')
-        Timecode('24', frames=12000)
+
+        Timecode(24, frames=12000)
+        Timecode(23.98, '00:00:00:00')
+        Timecode(24, '00:00:00:00')
+        Timecode(25, '00:00:00:00')
+        Timecode(29.97, '00:00:00;00')
+        Timecode(30, '00:00:00:00')
+        Timecode(50, '00:00:00:00')
+        Timecode(59.94, '00:00:00;00')
+        Timecode(60, '00:00:00:00')
+        Timecode(1000, '03:36:09.230')
+        Timecode(24, start_timecode=None, frames=12000)
+
+        Timecode(23.98)
+        Timecode(24)
+        Timecode(25)
+        Timecode(29.97)
+        Timecode(30)
+        Timecode(50)
+        Timecode(59.94)
+        Timecode(60)
+        Timecode(1000)
+        Timecode(24, frames=12000)
 
     def test_repr_overload(self):
         timeobj = Timecode('24', '01:00:00:00')
@@ -53,8 +75,8 @@ class TimecodeTester(unittest.TestCase):
         timeobj = Timecode('23.98', '20:00:00:00')
         self.assertEqual('20:00:00:00', timeobj.__repr__())
 
-        timeobj = Timecode('29.97', '00:09:00:00')
-        self.assertEqual('00:08:59:28', timeobj.__repr__())
+        timeobj = Timecode('29.97', '00:09:00;00')
+        self.assertEqual('00:08:59;28', timeobj.__repr__())
 
         timeobj = Timecode('30', '00:10:00:00')
         self.assertEqual('00:10:00:00', timeobj.__repr__())
@@ -62,11 +84,17 @@ class TimecodeTester(unittest.TestCase):
         timeobj = Timecode('60', '00:00:09:00')
         self.assertEqual('00:00:09:00', timeobj.__repr__())
 
-        timeobj = Timecode('59.94', '00:00:20:00')
-        self.assertEqual('00:00:20:00', timeobj.__repr__())
+        timeobj = Timecode('59.94', '00:00:20;00')
+        self.assertEqual('00:00:20;00', timeobj.__repr__())
 
-        timeobj = Timecode('ms', '00:00:00:900')
-        self.assertEqual('00:00:00:900', timeobj.__repr__())
+        timeobj = Timecode('59.94', '00:00:20;00')
+        self.assertNotEqual('00:00:20:00', timeobj.__repr__())
+
+        timeobj = Timecode('ms', '00:00:00.900')
+        self.assertEqual('00:00:00.900', timeobj.__repr__())
+
+        timeobj = Timecode('ms', '00:00:00.900')
+        self.assertNotEqual('00:00:00:900', timeobj.__repr__())
 
         timeobj = Timecode('24', frames=49)
         self.assertEqual('00:00:02:00', timeobj.__repr__())
@@ -75,16 +103,16 @@ class TimecodeTester(unittest.TestCase):
         """testing several timecode initialization
         """
         tc = Timecode('29.97')
-        self.assertEqual('00:00:00:00', tc.__str__())
+        self.assertEqual('00:00:00;00', tc.__str__())
         self.assertEqual(1, tc.frames)
 
-        tc = Timecode('29.97', '00:00:00:01')
+        tc = Timecode('29.97', '00:00:00;01')
         self.assertEqual(2, tc.frames)
 
-        tc = Timecode('29.97', '03:36:09:23')
+        tc = Timecode('29.97', '03:36:09;23')
         self.assertEqual(388704, tc.frames)
 
-        tc = Timecode('29.97', '03:36:09:23')
+        tc = Timecode('29.97', '03:36:09;23')
         self.assertEqual(388704, tc.frames)
 
         tc = Timecode('30', '03:36:09:23')
@@ -93,13 +121,13 @@ class TimecodeTester(unittest.TestCase):
         tc = Timecode('25', '03:36:09:23')
         self.assertEqual(324249, tc.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
+        tc = Timecode('59.94', '03:36:09;23')
         self.assertEqual(777384, tc.frames)
 
         tc = Timecode('60', '03:36:09:23')
         self.assertEqual(778164, tc.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
+        tc = Timecode('59.94', '03:36:09;23')
         self.assertEqual(777384, tc.frames)
 
         tc = Timecode('23.98', '03:36:09:23')
@@ -108,7 +136,7 @@ class TimecodeTester(unittest.TestCase):
         tc = Timecode('24', '03:36:09:23')
         self.assertEqual(311280, tc.frames)
 
-        tc = Timecode('ms', '03:36:09:230')
+        tc = Timecode('ms', '03:36:09.230')
         self.assertEqual(3, tc.hrs)
         self.assertEqual(36, tc.mins)
         self.assertEqual(9, tc.secs)
@@ -118,32 +146,32 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual('00:08:19:23', tc.__str__())
 
         tc = Timecode('29.97', frames=2589408)
-        self.assertEqual('23:59:59:29', tc.__str__())
+        self.assertEqual('23:59:59;29', tc.__str__())
 
         tc = Timecode('29.97', frames=2589409)
-        self.assertEqual('00:00:00:00', tc.__str__())
+        self.assertEqual('00:00:00;00', tc.__str__())
 
         tc = Timecode('59.94', frames=5178816)
-        self.assertEqual('23:59:59:59', tc.__str__())
+        self.assertEqual('23:59:59;59', tc.__str__())
 
         tc = Timecode('59.94', frames=5178817)
-        self.assertEqual('00:00:00:00', tc.__str__())
+        self.assertEqual('00:00:00;00', tc.__str__())
 
     def test_frame_to_tc(self):
-        tc = Timecode('29.97', '00:00:00:01')
+        tc = Timecode('29.97', '00:00:00;01')
         self.assertEqual(0, tc.hrs)
         self.assertEqual(0, tc.mins)
         self.assertEqual(0, tc.secs)
         self.assertEqual(1, tc.frs)
-        self.assertEqual('00:00:00:01', tc.__str__())
+        self.assertEqual('00:00:00;01', tc.__str__())
 
-        tc = Timecode('29.97', '03:36:09:23')
+        tc = Timecode('29.97', '03:36:09;23')
         self.assertEqual(3, tc.hrs)
         self.assertEqual(36, tc.mins)
         self.assertEqual(9, tc.secs)
         self.assertEqual(23, tc.frs)
 
-        tc = Timecode('29.97', '03:36:09:23')
+        tc = Timecode('29.97', '03:36:09;23')
         self.assertEqual(3, tc.hrs)
         self.assertEqual(36, tc.mins)
         self.assertEqual(9, tc.secs)
@@ -161,7 +189,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(9, tc.secs)
         self.assertEqual(23, tc.frs)
 
-        tc = Timecode('59.94', '03:36:09:23')
+        tc = Timecode('59.94', '03:36:09;23')
         self.assertEqual(3, tc.hrs)
         self.assertEqual(36, tc.mins)
         self.assertEqual(9, tc.secs)
@@ -173,7 +201,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(9, tc.secs)
         self.assertEqual(23, tc.frs)
 
-        tc = Timecode('59.94', '03:36:09:23')
+        tc = Timecode('59.94', '03:36:09;23')
         self.assertEqual(3, tc.hrs)
         self.assertEqual(36, tc.mins)
         self.assertEqual(9, tc.secs)
@@ -191,7 +219,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(9, tc.secs)
         self.assertEqual(23, tc.frs)
 
-        tc = Timecode('ms', '03:36:09:230')
+        tc = Timecode('ms', '03:36:09.230')
         self.assertEqual(3, tc.hrs)
         self.assertEqual(36, tc.mins)
         self.assertEqual(9, tc.secs)
@@ -207,51 +235,51 @@ class TimecodeTester(unittest.TestCase):
     def test_tc_to_frame_test_in_2997(self):
         """testing if timecode to frame conversion is ok in 2997
         """
-        tc = Timecode('29.97', '00:00:00:00')
+        tc = Timecode('29.97', '00:00:00;00')
         self.assertEqual(tc.frames, 1)
 
-        tc = Timecode('29.97', '00:00:00:21')
+        tc = Timecode('29.97', '00:00:00;21')
         self.assertEqual(tc.frames, 22)
 
-        tc = Timecode('29.97', '00:00:00:29')
+        tc = Timecode('29.97', '00:00:00;29')
         self.assertEqual(tc.frames, 30)
 
-        tc = Timecode('29.97', '00:00:00:60')
+        tc = Timecode('29.97', '00:00:00;60')
         self.assertEqual(tc.frames, 61)
 
-        tc = Timecode('29.97', '00:00:01:00')
+        tc = Timecode('29.97', '00:00:01;00')
         self.assertEqual(tc.frames, 31)
 
-        tc = Timecode('29.97', '00:00:10:00')
+        tc = Timecode('29.97', '00:00:10;00')
         self.assertEqual(tc.frames, 301)
 
         # test with non existing timecodes
-        tc = Timecode('29.97', '00:01:00:00')
+        tc = Timecode('29.97', '00:01:00;00')
         self.assertEqual(1799, tc.frames)
-        self.assertEqual('00:00:59:28', tc.__str__())
+        self.assertEqual('00:00:59;28', tc.__str__())
 
         # test the limit
-        tc = Timecode('29.97', '23:59:59:29')
+        tc = Timecode('29.97', '23:59:59;29')
         self.assertEqual(2589408, tc.frames)
 
     def test_drop_frame(self):
-        tc = Timecode('29.97', '13:36:59:29')
+        tc = Timecode('29.97', '13:36:59;29')
         timecode = tc.next()
-        self.assertEqual("13:37:00:02", timecode.__str__())
+        self.assertEqual("13:37:00;02", timecode.__str__())
 
-        tc = Timecode('59.94', '13:36:59:59')
-        self.assertEqual("13:36:59:59", tc.__str__())
+        tc = Timecode('59.94', '13:36:59;59')
+        self.assertEqual("13:36:59;59", tc.__str__())
 
         timecode = tc.next()
-        self.assertEqual("13:37:00:04", timecode.__str__())
+        self.assertEqual("13:37:00;04", timecode.__str__())
 
-        tc = Timecode('59.94', '13:39:59:59')
+        tc = Timecode('59.94', '13:39:59;59')
         timecode = tc.next()
-        self.assertEqual("13:40:00:00", timecode.__str__())
+        self.assertEqual("13:40:00;00", timecode.__str__())
 
-        tc = Timecode('29.97', '13:39:59:29')
+        tc = Timecode('29.97', '13:39:59;29')
         timecode = tc.next()
-        self.assertEqual("13:40:00:00", timecode.__str__())
+        self.assertEqual("13:40:00;00", timecode.__str__())
 
     def test_setting_frame_rate_to_2997_forces_drop_frame(self):
         """testing if setting the frame rate to 29.97 forces the dropframe to
@@ -273,20 +301,30 @@ class TimecodeTester(unittest.TestCase):
         tc = Timecode('59.94')
         self.assertTrue(tc.drop_frame)
 
+    def test_setting_frame_rate_to_ms_or_1000_forces_drop_frame(self):
+        """testing if setting the frame rate to 59.94 forces the dropframe to
+        True
+        """
+        tc = Timecode('ms')
+        self.assertTrue(tc.ms_frame)
+
+        tc = Timecode('1000')
+        self.assertTrue(tc.ms_frame)
+
     def test_iteration(self):
-        tc = Timecode('29.97', '03:36:09:23')
-        self.assertEqual("03:36:09:23", tc)
+        tc = Timecode('29.97', '03:36:09;23')
+        self.assertEqual("03:36:09;23", tc)
         for x in range(60):
             t = tc.next()
             self.assertTrue(t)
-        self.assertEqual("03:36:11:23", t)
+        self.assertEqual("03:36:11;23", t)
         self.assertEqual(388764, tc.frames)
 
-        tc = Timecode('29.97', '03:36:09:23')
+        tc = Timecode('29.97', '03:36:09;23')
         for x in range(60):
             t = tc.next()
             self.assertTrue(t)
-        self.assertEqual("03:36:11:23", t)
+        self.assertEqual("03:36:11;23", t)
         self.assertEqual(388764, tc.frames)
 
         tc = Timecode('30', '03:36:09:23')
@@ -303,11 +341,11 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:36:12:08", t)
         self.assertEqual(324309, tc.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
+        tc = Timecode('59.94', '03:36:09;23')
         for x in range(60):
             t = tc.next()
             self.assertTrue(t)
-        self.assertEqual("03:36:10:23", t)
+        self.assertEqual("03:36:10;23", t)
         self.assertEqual(777444, tc.frames)
 
         tc = Timecode('60', '03:36:09:23')
@@ -338,11 +376,11 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:36:12:11", t)
         self.assertEqual(311340, tc.frames)
 
-        tc = Timecode('ms', '03:36:09:230')
+        tc = Timecode('ms', '03:36:09.230')
         for x in range(60):
             t = tc.next()
             self.assertIsNotNone(t)
-        self.assertEqual('03:36:09:290', t)
+        self.assertEqual('03:36:09.290', t)
         self.assertEqual(12969291, tc.frames)
 
         tc = Timecode('24', frames=12000)
@@ -353,22 +391,22 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(12060, tc.frames)
 
     def test_op_overloads_add(self):
-        tc = Timecode('29.97', '03:36:09:23')
-        tc2 = Timecode('29.97', '00:00:29:23')
+        tc = Timecode('29.97', '03:36:09;23')
+        tc2 = Timecode('29.97', '00:00:29;23')
         d = tc + tc2
         f = tc + 894
-        self.assertEqual("03:36:39:17", d.__str__())
+        self.assertEqual("03:36:39;17", d.__str__())
         self.assertEqual(389598, d.frames)
-        self.assertEqual("03:36:39:17", f.__str__())
+        self.assertEqual("03:36:39;17", f.__str__())
         self.assertEqual(389598, f.frames)
 
-        tc = Timecode('29.97', '03:36:09:23')
-        tc2 = Timecode('29.97', '00:00:29:23')
+        tc = Timecode('29.97', '03:36:09;23')
+        tc2 = Timecode('29.97', '00:00:29;23')
         d = tc + tc2
         f = tc + 894
-        self.assertEqual("03:36:39:17", d.__str__())
+        self.assertEqual("03:36:39;17", d.__str__())
         self.assertEqual(389598, d.frames)
-        self.assertEqual("03:36:39:17", f.__str__())
+        self.assertEqual("03:36:39;17", f.__str__())
         self.assertEqual(389598, f.frames)
 
         tc = Timecode('30', '03:36:09:23')
@@ -390,14 +428,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:36:39:22", f.__str__())
         self.assertEqual(324998, f.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
-        tc2 = Timecode('59.94', '00:00:29:23')
+        tc = Timecode('59.94', '03:36:09;23')
+        tc2 = Timecode('59.94', '00:00:29;23')
         self.assertEqual(1764, tc2.frames)
         d = tc + tc2
         f = tc + 1764
-        self.assertEqual("03:36:38:47", d.__str__())
+        self.assertEqual("03:36:38;47", d.__str__())
         self.assertEqual(779148, d.frames)
-        self.assertEqual("03:36:38:47", f.__str__())
+        self.assertEqual("03:36:38;47", f.__str__())
         self.assertEqual(779148, f.frames)
 
         tc = Timecode('60', '03:36:09:23')
@@ -410,14 +448,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:36:38:47", f.__str__())
         self.assertEqual(779928, f.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
-        tc2 = Timecode('59.94', '00:00:29:23')
+        tc = Timecode('59.94', '03:36:09;23')
+        tc2 = Timecode('59.94', '00:00:29;23')
         self.assertEqual(1764, tc2.frames)
         d = tc + tc2
         f = tc + 1764
-        self.assertEqual("03:36:38:47", d.__str__())
+        self.assertEqual("03:36:38;47", d.__str__())
         self.assertEqual(779148, d.frames)
-        self.assertEqual("03:36:38:47", f.__str__())
+        self.assertEqual("03:36:38;47", f.__str__())
         self.assertEqual(779148, f.frames)
 
         tc = Timecode('23.98', '03:36:09:23')
@@ -440,14 +478,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:36:39:23", f.__str__())
         self.assertEqual(312000, f.frames)
 
-        tc = Timecode('ms', '03:36:09:230')
-        tc2 = Timecode('ms', '01:06:09:230')
+        tc = Timecode('ms', '03:36:09.230')
+        tc2 = Timecode('ms', '01:06:09.230')
         self.assertEqual(3969231, tc2.frames)
         d = tc + tc2
         f = tc + 720
-        self.assertEqual("04:42:18:461", d.__str__())
+        self.assertEqual("04:42:18.461", d.__str__())
         self.assertEqual(16938462, d.frames)
-        self.assertEqual("03:36:09:950", f.__str__())
+        self.assertEqual("03:36:09.950", f.__str__())
         self.assertEqual(12969951, f.frames)
 
         tc = Timecode('24', frames=12000)
@@ -464,12 +502,12 @@ class TimecodeTester(unittest.TestCase):
         """testing if the resultant object will have the left sides frame rate
         when two timecodes with different frame rates are added together
         """
-        tc1 = Timecode('29.97', '00:00:00:00')
+        tc1 = Timecode('29.97', '00:00:00;00')
         tc2 = Timecode('24', '00:00:00:10')
         tc3 = tc1 + tc2
         self.assertEqual('29.97', tc3.framerate)
         self.assertEqual(12, tc3.frames)
-        self.assertEqual('00:00:00:11', tc3)
+        self.assertEqual('00:00:00;11', tc3)
 
     def test_frame_number_attribute_value_is_correctly_calculated(self):
         """testing if the Timecode.frame_number attribute is correctly
@@ -483,7 +521,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(25, tc2.frames)
         self.assertEqual(24, tc2.frame_number)
 
-        tc3 = Timecode('29.97', '00:01:00:00')
+        tc3 = Timecode('29.97', '00:01:00;00')
         self.assertEqual(1799, tc3.frames)
         self.assertEqual(1798, tc3.frame_number)
 
@@ -495,7 +533,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(3001, tc5.frames)
         self.assertEqual(3000, tc5.frame_number)
 
-        tc6 = Timecode('59.94', '00:01:00:00')
+        tc6 = Timecode('59.94', '00:01:00;00')
         self.assertEqual(3597, tc6.frames)
         self.assertEqual(3596, tc6.frame_number)
 
@@ -504,23 +542,23 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(3600, tc7.frame_number)
 
     def test_op_overloads_subtract(self):
-        tc = Timecode('29.97', '03:36:09:23')
-        tc2 = Timecode('29.97', '00:00:29:23')
+        tc = Timecode('29.97', '03:36:09;23')
+        tc2 = Timecode('29.97', '00:00:29;23')
         self.assertEqual(894, tc2.frames)
         d = tc - tc2
         f = tc - 894
-        self.assertEqual("03:35:39:27", d.__str__())
+        self.assertEqual("03:35:39;27", d.__str__())
         self.assertEqual(387810, d.frames)
-        self.assertEqual("03:35:39:27", f.__str__())
+        self.assertEqual("03:35:39;27", f.__str__())
         self.assertEqual(387810, f.frames)
 
-        tc = Timecode('29.97', '03:36:09:23')
-        tc2 = Timecode('29.97', '00:00:29:23')
+        tc = Timecode('29.97', '03:36:09;23')
+        tc2 = Timecode('29.97', '00:00:29;23')
         d = tc - tc2
         f = tc - 894
-        self.assertEqual("03:35:39:27", d.__str__())
+        self.assertEqual("03:35:39;27", d.__str__())
         self.assertEqual(387810, d.frames)
-        self.assertEqual("03:35:39:27", f.__str__())
+        self.assertEqual("03:35:39;27", f.__str__())
         self.assertEqual(387810, f.frames)
 
         tc = Timecode('30', '03:36:09:23')
@@ -542,14 +580,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:35:39:24", f.__str__())
         self.assertEqual(323500, f.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
-        tc2 = Timecode('59.94', '00:00:29:23')
+        tc = Timecode('59.94', '03:36:09;23')
+        tc2 = Timecode('59.94', '00:00:29;23')
         self.assertEqual(1764, tc2.frames)
         d = tc - tc2
         f = tc - 1764
-        self.assertEqual("03:35:39:55", d.__str__())
+        self.assertEqual("03:35:39;55", d.__str__())
         self.assertEqual(775620, d.frames)
-        self.assertEqual("03:35:39:55", f.__str__())
+        self.assertEqual("03:35:39;55", f.__str__())
         self.assertEqual(775620, f.frames)
 
         tc = Timecode('60', '03:36:09:23')
@@ -562,13 +600,13 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:35:39:59", f.__str__())
         self.assertEqual(776400, f.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
-        tc2 = Timecode('59.94', '00:00:29:23')
+        tc = Timecode('59.94', '03:36:09;23')
+        tc2 = Timecode('59.94', '00:00:29;23')
         d = tc - tc2
         f = tc - 1764
-        self.assertEqual("03:35:39:55", d.__str__())
+        self.assertEqual("03:35:39;55", d.__str__())
         self.assertEqual(775620, d.frames)
-        self.assertEqual("03:35:39:55", f.__str__())
+        self.assertEqual("03:35:39;55", f.__str__())
         self.assertEqual(775620, f.frames)
 
         tc = Timecode('23.98', '03:36:09:23')
@@ -590,14 +628,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("03:35:39:23", f.__str__())
         self.assertEqual(310560, f.frames)
 
-        tc = Timecode('ms', '03:36:09:230')
-        tc2 = Timecode('ms', '01:06:09:230')
+        tc = Timecode('ms', '03:36:09.230')
+        tc2 = Timecode('ms', '01:06:09.230')
         self.assertEqual(3969231, tc2.frames)
         d = tc - tc2
         f = tc - 3969231
-        self.assertEqual("02:29:59:999", d.__str__())
+        self.assertEqual("02:29:59.999", d.__str__())
         self.assertEqual(9000000, d.frames)
-        self.assertEqual("02:29:59:999", f.__str__())
+        self.assertEqual("02:29:59.999", f.__str__())
         self.assertEqual(9000000, f.frames)
 
         tc = Timecode('24', frames=12000)
@@ -611,22 +649,22 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(11515, f.frames)
 
     def test_op_overloads_mult(self):
-        tc = Timecode('29.97', '00:00:09:23')
-        tc2 = Timecode('29.97', '00:00:29:23')
+        tc = Timecode('29.97', '00:00:09;23')
+        tc2 = Timecode('29.97', '00:00:29;23')
         d = tc * tc2
         f = tc * 4
-        self.assertEqual("02:26:09:29", d.__str__())
+        self.assertEqual("02:26:09;29", d.__str__())
         self.assertEqual(262836, d.frames)
-        self.assertEqual("00:00:39:05", f.__str__())
+        self.assertEqual("00:00:39;05", f.__str__())
         self.assertEqual(1176, f.frames)
 
-        tc = Timecode('29.97', '00:00:09:23')
-        tc2 = Timecode('29.97', '00:00:29:23')
+        tc = Timecode('29.97', '00:00:09;23')
+        tc2 = Timecode('29.97', '00:00:29;23')
         d = tc * tc2
         f = tc * 4
-        self.assertEqual("02:26:09:29", d.__str__())
+        self.assertEqual("02:26:09;29", d.__str__())
         self.assertEqual(262836, d.frames)
-        self.assertEqual("00:00:39:05", f.__str__())
+        self.assertEqual("00:00:39;05", f.__str__())
         self.assertEqual(1176, f.frames)
 
         tc = Timecode('30', '03:36:09:23')
@@ -648,14 +686,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("10:28:20:00", f.__str__())
         self.assertEqual(242862501, f.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
-        tc2 = Timecode('59.94', '00:00:29:23')
+        tc = Timecode('59.94', '03:36:09;23')
+        tc2 = Timecode('59.94', '00:00:29;23')
         self.assertEqual(1764, tc2.frames)
         d = tc * tc2
         f = tc * 1764
-        self.assertEqual("18:59:27:35", d.__str__())
+        self.assertEqual("18:59:27;35", d.__str__())
         self.assertEqual(1371305376, d.frames)
-        self.assertEqual("18:59:27:35", f.__str__())
+        self.assertEqual("18:59:27;35", f.__str__())
         self.assertEqual(1371305376, f.frames)
 
         tc = Timecode('60', '03:36:09:23')
@@ -668,13 +706,13 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("19:00:21:35", f.__str__())
         self.assertEqual(1372681296, f.frames)
 
-        tc = Timecode('59.94', '03:36:09:23')
-        tc2 = Timecode('59.94', '00:00:29:23')
+        tc = Timecode('59.94', '03:36:09;23')
+        tc2 = Timecode('59.94', '00:00:29;23')
         d = tc * tc2
         f = tc * 1764
-        self.assertEqual("18:59:27:35", d.__str__())
+        self.assertEqual("18:59:27;35", d.__str__())
         self.assertEqual(1371305376, d.frames)
-        self.assertEqual("18:59:27:35", f.__str__())
+        self.assertEqual("18:59:27;35", f.__str__())
         self.assertEqual(1371305376, f.frames)
 
         tc = Timecode('23.98', '03:36:09:23')
@@ -687,14 +725,14 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual("04:09:35:23", f.__str__())
         self.assertEqual(224121600, f.frames)
 
-        tc = Timecode('ms', '03:36:09:230')
-        tc2 = Timecode('ms', '01:06:09:230')
+        tc = Timecode('ms', '03:36:09.230')
+        tc2 = Timecode('ms', '01:06:09.230')
         self.assertEqual(3969231, tc2.frames)
         d = tc * tc2
         f = tc * 3969231
-        self.assertEqual("17:22:11:360", d.__str__())
+        self.assertEqual("17:22:11.360", d.__str__())
         self.assertEqual(51477873731361, d.frames)
-        self.assertEqual("17:22:11:360", f.__str__())
+        self.assertEqual("17:22:11.360", f.__str__())
         self.assertEqual(51477873731361, f.frames)
 
         tc = Timecode('24', frames=12000)
@@ -726,40 +764,40 @@ class TimecodeTester(unittest.TestCase):
         """testing if the timecode will loop back to 00:00:00:00 after 24 hours
         in 29.97 fps
         """
-        tc = Timecode('29.97', '00:00:00:21')
+        tc = Timecode('29.97', '00:00:00;21')
         self.assertTrue(tc.drop_frame)
         self.assertEqual(22, tc.frames)
 
-        tc2 = Timecode('29.97', '23:59:59:29')
+        tc2 = Timecode('29.97', '23:59:59;29')
         self.assertTrue(tc2.drop_frame)
         self.assertEqual(2589408, tc2.frames)
 
         self.assertEqual(
-            '00:00:00:21',
+            '00:00:00;21',
             tc.__repr__()
         )
         self.assertEqual(
-            '23:59:59:29',
+            '23:59:59;29',
             tc2.__repr__()
         )
 
         self.assertEqual(
-            '00:00:00:21',
+            '00:00:00;21',
             (tc + tc2).__str__()
         )
 
         self.assertEqual(
-            '02:00:00:00',
+            '02:00:00;00',
             (tc2 + 215785).__str__()
         )
 
         self.assertEqual(
-            '02:00:00:00',
+            '02:00:00;00',
             (tc2 + 215785 + 2589408).__str__()
         )
 
         self.assertEqual(
-            '02:00:00:00',
+            '02:00:00;00',
             (tc2 + 215785 + 2589408 + 2589408).__str__()
         )
 
@@ -767,53 +805,53 @@ class TimecodeTester(unittest.TestCase):
         """testing if the timecode will loop back to 00:00:00:00 after 24 hours
         in 29.97 fps
         """
-        tc0 = Timecode('59.94', '23:59:59:29')
+        tc0 = Timecode('59.94', '23:59:59;29')
         self.assertEqual(5178786, tc0.frames)
-        tc0 = Timecode('29.97', '23:59:59:29')
+        tc0 = Timecode('29.97', '23:59:59;29')
         self.assertEqual(2589408, tc0.frames)
 
         tc1 = Timecode('29.97', frames=2589408)
-        self.assertEqual('23:59:59:29', tc1.__str__())
+        self.assertEqual('23:59:59;29', tc1.__str__())
 
-        tc2 = Timecode('29.97', '23:59:59:29')
+        tc2 = Timecode('29.97', '23:59:59;29')
         tc3 = tc2 + 1
-        self.assertEqual('00:00:00:00', tc3.__str__())
+        self.assertEqual('00:00:00;00', tc3.__str__())
 
-        tc2 = Timecode('29.97', '23:59:59:29')
+        tc2 = Timecode('29.97', '23:59:59;29')
         tc3 = tc2 + 21
-        self.assertEqual('00:00:00:20', tc3.__str__())
+        self.assertEqual('00:00:00;20', tc3.__str__())
 
-        tc = Timecode('29.97', '00:00:00:21')
-        tc2 = Timecode('29.97', '23:59:59:29')
+        tc = Timecode('29.97', '00:00:00;21')
+        tc2 = Timecode('29.97', '23:59:59;29')
         tc3 = (tc + tc2)
-        self.assertEqual('00:00:00:21', tc3.__str__())
+        self.assertEqual('00:00:00;21', tc3.__str__())
 
-        tc = Timecode('29.97', '04:20:13:21')
+        tc = Timecode('29.97', '04:20:13;21')
         tca = Timecode('29.97', frames=467944)
         self.assertEqual(467944, tca.frames)
         self.assertEqual(467944, tc.frames)
-        self.assertEqual('04:20:13:21', tca.__str__())
-        self.assertEqual('04:20:13:21', tc.__str__())
+        self.assertEqual('04:20:13;21', tca.__str__())
+        self.assertEqual('04:20:13;21', tc.__str__())
 
-        tc2 = Timecode('29.97', '23:59:59:29')
+        tc2 = Timecode('29.97', '23:59:59;29')
         self.assertEqual(2589408, tc2.frames)
-        self.assertEqual('23:59:59:29', tc2.__str__())
+        self.assertEqual('23:59:59;29', tc2.__str__())
         tc2a = Timecode('29.97', frames=2589408)
         self.assertEqual(2589408, tc2a.frames)
-        self.assertEqual('23:59:59:29', tc2a.__str__())
+        self.assertEqual('23:59:59;29', tc2a.__str__())
 
         tc3 = (tc + tc2)
-        self.assertEqual('04:20:13:21', tc3.__str__())
+        self.assertEqual('04:20:13;21', tc3.__str__())
 
-        tc = Timecode('59.94', '04:20:13:21')
-        self.assertEqual('04:20:13:21', tc.__str__())
+        tc = Timecode('59.94', '04:20:13;21')
+        self.assertEqual('04:20:13;21', tc.__str__())
 
         tca = Timecode('59.94', frames=935866)
-        self.assertEqual('04:20:13:21', tc.__str__())
+        self.assertEqual('04:20:13;21', tca.__str__())
 
-        tc2 = Timecode('59.94', '23:59:59:59')
+        tc2 = Timecode('59.94', '23:59:59;59')
         tc3 = (tc + tc2)
-        self.assertEqual('04:20:13:21', tc3.__str__())
+        self.assertEqual('04:20:13;21', tc3.__str__())
 
     def test_framerate_can_be_changed(self):
         """testing if the timecode value will be automaticall updated when the
@@ -832,68 +870,68 @@ class TimecodeTester(unittest.TestCase):
     #     """
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('23.98', '01:20:30:303')
-    # 
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:303',
     #         cm.exception.__str__()
     #     )
-    # 
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('24', '01:20:30:303')
-    #     
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:303',
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('29.97', '01:20:30:303')
-    #     
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:303',
     #         cm.exception.__str__()
     #     )
-    # 
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('30', '01:20:30:303')
-    #     
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:303',
     #         cm.exception.__str__()
     #     )
-    # 
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('59.94', '01:20:30:303')
-    #     
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:303',
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('60', '01:20:30:303')
-    #     
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:303',
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('ms', '01:20:30:3039')
-    #     
+    #
     #     self.assertEqual(
     #         'Timecode string parsing error. 01:20:30:3039',
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     with self.assertRaises(TimecodeError) as cm:
     #         Timecode('60', '01:20:30:30')
-    #     
+    #
     #     self.assertEqual(
     #         'Drop frame with 60fps not supported, only 29.97 & 59.94.',
     #         cm.exception.__str__(),
     #     )
-    #     
+    #
     #     tc = Timecode('29.97', '00:00:09:23')
     #     tc2 = 'bum'
     #     with self.assertRaises(TimecodeError) as cm:
@@ -902,32 +940,32 @@ class TimecodeTester(unittest.TestCase):
     #         "Type str not supported for arithmetic.",
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     tc = Timecode('30', '00:00:09:23')
     #     tc2 = 'bum'
     #     with self.assertRaises(TimecodeError) as cm:
     #         d = tc + tc2
-    #     
+    #
     #     self.assertEqual(
     #         "Type str not supported for arithmetic.",
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     tc = Timecode('24', '00:00:09:23')
     #     tc2 = 'bum'
     #     with self.assertRaises(TimecodeError) as cm:
     #         d = tc - tc2
-    #     
+    #
     #     self.assertEqual(
     #         "Type str not supported for arithmetic.",
     #         cm.exception.__str__()
     #     )
-    #     
+    #
     #     tc = Timecode('ms', '00:00:09:237')
     #     tc2 = 'bum'
     #     with self.assertRaises(TimecodeError) as cm:
     #         d = tc / tc2
-    #     
+    #
     #     self.assertEqual(
     #         "Type str not supported for arithmetic.",
     #         cm.exception.__str__()

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -34,7 +34,7 @@ class Timecode(object):
         frames, then when required it converts the frames to a timecode by
         using the frame rate setting.
 
-        :param str framerate: The frame rate of the Timecode instance. It
+        :param framerate: The frame rate of the Timecode instance. It
           should be one of ['23.98', '24', '25', '29.97', '30', '50', '59.94',
           '60', 'ms'] where "ms" equals to 1000 fps. Can not be skipped.
           Setting the framerate will automatically set the :attr:`.drop_frame`
@@ -45,12 +45,14 @@ class Timecode(object):
           skipped then the start_second attribute will define the start
           timecode, and if start_seconds is also skipped then the default value
           of '00:00:00:00' will be used.
+        :type framerate: str or int or float
         :type start_timecode: str or None
         :param start_seconds: A float or integer value showing the seconds.
         :param int frames: Timecode objects can be initialized with an
           integer number showing the total frames.
         """
         self.drop_frame = False
+        self.ms_frame = False
         self._int_framerate = None
         self._framerate = None
         self.framerate = framerate
@@ -77,11 +79,17 @@ class Timecode(object):
         return self._framerate
 
     @framerate.setter
-    def framerate(self, framerate):
+    def framerate(self, framerate):  # lint:ok
         """setter for the framerate attribute
         :param framerate:
         :return:
         """
+
+        # check if number is passed and if so convert it to a string
+        if isinstance(framerate, (int, float)):
+            # filter out milliseconds logic
+            framerate = str(framerate)
+
         # set the int_frame_rate
         if framerate == '29.97':
             self._int_framerate = 30
@@ -91,8 +99,9 @@ class Timecode(object):
             self.drop_frame = True
         elif framerate == '23.98':
             self._int_framerate = 24
-        elif framerate == 'ms':
+        elif framerate in ['ms', '1000']:
             self._int_framerate = 1000
+            self.ms_frame = True
             framerate = 1000
         elif framerate == 'frames':
             self._int_framerate = 1
@@ -114,7 +123,8 @@ class Timecode(object):
     def tc_to_frames(self, timecode):
         """Converts the given timecode to frames
         """
-        hours, minutes, seconds, frames = map(int, timecode.split(':'))
+        hours, minutes, seconds, frames = map(int,
+                                              self.parse_timecode(timecode))
 
         ffps = float(self._framerate)
 
@@ -169,7 +179,7 @@ class Timecode(object):
         frames_per_10_minutes = int(round(ffps * 60 * 10))
         # Number of frames per minute is the round of the framerate * 60 minus
         # the number of dropped frames
-        frames_per_minute = int(round(ffps)*60) - drop_frames
+        frames_per_minute = int(round(ffps) * 60) - drop_frames
 
         frame_number = frames - 1
 
@@ -198,10 +208,17 @@ class Timecode(object):
 
         return hrs, mins, secs, frs
 
+    def tc_to_string(self, hrs, mins, secs, frs):
+        return "%02d:%02d:%02d%s%02d" % (hrs,
+                                         mins,
+                                         secs,
+                                         self.frame_delimiter,
+                                         frs)
+
     @classmethod
     def parse_timecode(cls, timecode):
         """parses timecode string frames '00:00:00:00' or '00:00:00;00' or
-        milliseconds '00:00:00:000'
+        milliseconds '00:00:00.000'
         """
         bfr = timecode.replace(';', ':').replace('.', ':').split(':')
         hrs = int(bfr[0])
@@ -209,6 +226,18 @@ class Timecode(object):
         secs = int(bfr[2])
         frs = int(bfr[3])
         return hrs, mins, secs, frs
+
+    @property
+    def frame_delimiter(self):
+        """Return correct symbol based on framerate."""
+        if self.drop_frame:
+            return ';'
+
+        elif self.ms_frame:
+            return '.'
+
+        else:
+            return ':'
 
     def __iter__(self):
         return self
@@ -282,8 +311,8 @@ class Timecode(object):
                 'Type %s not supported for arithmetic.' %
                 other.__class__.__name__
             )
-        return Timecode(self._framerate, start_timecode=None,
-                        frames=subtracted_frames)
+
+        return Timecode(self._framerate, frames=subtracted_frames)
 
     def __mul__(self, other):
         """returns new Timecode object with added timecodes"""
@@ -296,8 +325,8 @@ class Timecode(object):
                 'Type %s not supported for arithmetic.' %
                 other.__class__.__name__
             )
-        return Timecode(self._framerate, start_timecode=None,
-                        frames=multiplied_frames)
+
+        return Timecode(self._framerate, frames=multiplied_frames)
 
     def __div__(self, other):
         """returns new Timecode object with added timecodes"""
@@ -310,12 +339,11 @@ class Timecode(object):
                 'Type %s not supported for arithmetic.' %
                 other.__class__.__name__
             )
-        return Timecode(self._framerate, start_timecode=None,
-                        frames=div_frames)
+
+        return Timecode(self._framerate, frames=div_frames)
 
     def __repr__(self):
-        return "%02d:%02d:%02d:%02d" % \
-            self.frames_to_tc(self.frames)
+        return self.tc_to_string(*self.frames_to_tc(self.frames))
 
     @property
     def hrs(self):

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 
 class Timecode(object):
@@ -87,7 +87,6 @@ class Timecode(object):
 
         # check if number is passed and if so convert it to a string
         if isinstance(framerate, (int, float)):
-            # filter out milliseconds logic
             framerate = str(framerate)
 
         # set the int_frame_rate
@@ -217,7 +216,7 @@ class Timecode(object):
 
     @classmethod
     def parse_timecode(cls, timecode):
-        """parses timecode string frames '00:00:00:00' or '00:00:00;00' or
+        """parses timecode string NDF '00:00:00:00' or DF '00:00:00;00' or
         milliseconds '00:00:00.000'
         """
         bfr = timecode.replace(';', ':').replace('.', ':').split(':')


### PR DESCRIPTION
My use for time codes are based on parsing and creating  EDL's from/to various sources. In my experience Drop-Frame time codes are represented with a ";" as a frame delimiter and "." for milliseconds. I would like that this module reflects that norm.
I also find it natural to pass frame rate as int or float and added support for that in addition to stings.
