### PR TITLE
Set framerate to 24 when specified as 23.98

### DIFF
--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -90,6 +90,7 @@ class Timecode(object):
             self._int_framerate = 60
             self.drop_frame = True
         elif framerate == '23.98':
+            framerate = '24'
             self._int_framerate = 24
         elif framerate == 'ms':
             self._int_framerate = 1000


### PR DESCRIPTION
There is no Drop Frame mode for 23.98 fps. Therefore timecodes for a
framerate of 23.98 will be identical to those with a framerate of
24 fps. This change removes the false distinction between 23.98 fps
and 24 fps timecode.

Without this change, when the framerate is specified as 23.98 fps
the midnight wrap-around of the timecode value occurs too soon:

`Timecode("23.98", frames=2071872)` gives "23:58:47:23"

`Timecode("23.98", frames=2071873)` gives "00:00:00:00"