### PR TITLE
Support specifying an integer timecode as a float

### DIFF
--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -68,6 +68,14 @@ class TimecodeTester(unittest.TestCase):
         Timecode(1000)
         Timecode(24, frames=12000)
 
+        Timecode(24.0)
+        Timecode(25.0)
+        Timecode(30.0)
+        Timecode(50.0)
+        Timecode(60.0)
+        Timecode(1000.0)
+        Timecode(24.0, frames=12000)
+
     def test_repr_overload(self):
         timeobj = Timecode('24', '01:00:00:00')
         self.assertEqual('01:00:00:00', timeobj.__repr__())

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -106,7 +106,7 @@ class Timecode(object):
         elif framerate == 'frames':
             self._int_framerate = 1
         else:
-            self._int_framerate = int(framerate)
+            self._int_framerate = int(float(framerate))
 
         self._framerate = framerate
 


### PR DESCRIPTION
Code that uses this module may take user input for a framerate, sometimes
resulting in a floating point number like "24.0".  This fixes the "ValueError:
invalid literal for int() with base 10: '24.0'" that would result.  Passes all
existing tests, and I added a few more for this condition.