### PR TITLE
Suggested Major release update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 Changes
 =======
 
+0.4.2
+=====
+
+* **Update:** Version bump for PyPI.
+
 0.4.1
 =====
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,9 @@ Changes
 
 * **New:** Added support for passing rational frame rate. 24000/1001 for 23.97 etc.
 
+* **New:** Added tests for new functionality. Fractional seconds and
+  rational frame rates.
+
 * **Fixed:** fractional seconds
 
 0.4.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,6 @@ Changes
 
 * **Fixed:** fractional seconds
 
-
 0.4.3
 =====
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 =======
 Changes
 =======
+0.5.0
+=====
+
+* **Important:** When passing frational second style timecode, the Timecode.frs
+  will return a float representing the fration of a second.
+  This is a major change for people expecting int values
+
+* **New:** Added support for passing rational frame rate. 24000/1001 for 23.97 etc.
+
+* **Fixed:** fractional seconds
+
 
 0.4.3
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 Changes
 =======
 
+0.4.1
+=====
+
+* **Fix:** Fixed a test that was testing overloaded operators.
+
 0.4.0
 =====
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,28 +1,23 @@
 =======
 Changes
 =======
-0.5.0
+1.0.0
 =====
-
-* **Important:** When passing frational second style timecode, the Timecode.frs
-  will return a float representing the fration of a second.
-  This is a major change for people expecting int values
 
 * **New:** Added support for passing rational frame rate. 24000/1001 for 23.97 etc.
 
 * **New:** Added tests for new functionality. Fractional seconds and
   rational frame rates.
 
-* **Fixed:** fractional seconds
-
-0.4.3
-=====
-
 * **New:** added __ge__ and __le__ methods for better comparison between two
   timecodes.
 
 * **New:** Added support for fractional seconds in the frame field as used in
   ffmpeg's duration for instance.
+
+* **Important:** When passing frational second style timecode, the Timecode.frs
+  will return a float representing the fration of a second.
+  This is a major change for people expecting int values
 
 0.4.2
 =====

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -45,6 +45,13 @@ class TimecodeTester(unittest.TestCase):
         Timecode('60')
         Timecode('ms')
 
+        Timecode('24000/1000', '00:00:00:00')
+        Timecode('24000/1001', '00:00:00;00')
+        Timecode('30000/1000', '00:00:00:00')
+        Timecode('30000/1001', '00:00:00;00')
+        Timecode('60000/1000', '00:00:00:00')
+        Timecode('60000/1001', '00:00:00;00')
+
         Timecode(24, frames=12000)
         Timecode(23.98, '00:00:00:00')
         Timecode(24, '00:00:00:00')
@@ -865,6 +872,56 @@ class TimecodeTester(unittest.TestCase):
         tc1.framerate = '12'
         self.assertEqual('00:00:08:03', tc1.__str__())
         self.assertEqual(100, tc1.frames)
+
+    def test_rational_framerate_convertions(self):
+        tc = Timecode('24000/1000', '00:00:00:00')
+        self.assertEqual(tc.framerate, '24')
+        self.assertEqual(tc._int_framerate, 24)
+
+        tc = Timecode('24000/1001', '00:00:00;00')
+        self.assertEqual(tc.framerate, '24')
+        self.assertEqual(tc._int_framerate, 24)
+
+        tc = Timecode('30000/1000', '00:00:00:00')
+        self.assertEqual(tc.framerate, '30')
+        self.assertEqual(tc._int_framerate, 30)
+
+        tc = Timecode('30000/1001', '00:00:00;00')
+        self.assertEqual(tc.framerate, '29.97')
+        self.assertEqual(tc._int_framerate, 30)
+
+        tc = Timecode('60000/1000', '00:00:00:00')
+        self.assertEqual(tc.framerate, '60')
+        self.assertEqual(tc._int_framerate, 60)
+
+        tc = Timecode('60000/1001', '00:00:00;00')
+        self.assertEqual(tc.framerate, '59.94')
+        self.assertEqual(tc._int_framerate, 60)
+
+    def test_rational_frame_delimiter(self):
+        tc = Timecode('24000/1000', frames=1)
+        self.assertFalse(';' in tc.__repr__())
+
+        tc = Timecode('24000/1001', frames=1)
+        self.assertFalse(';' in tc.__repr__())
+
+        tc = Timecode('30000/1001', frames=1)
+        self.assertTrue(';' in tc.__repr__())
+
+    def test_ms_vs_fraction_frames(self):
+        tc1 = Timecode('ms', '00:00:00.040')
+        self.assertTrue(tc1.ms_frame)
+        self.assertFalse(tc1.fraction_frame)
+
+        tc2 = Timecode(24, '00:00:00.042')
+        self.assertTrue(tc2.fraction_frame)
+        self.assertFalse(tc2.ms_frame)
+
+        self.assertNotEqual(tc1, tc2)
+
+        self.assertEqual(tc1.frame_number, 40)
+        self.assertEqual(tc2.frame_number, 1)
+
 
     # def test_exceptions(self):
     #     """test exceptions

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -922,6 +922,26 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(tc1.frame_number, 40)
         self.assertEqual(tc2.frame_number, 1)
 
+    def test_ge_overload(self):
+        tc1 = Timecode(24, '00:00:00:00')
+        tc2 = Timecode(24, '00:00:00:00')
+        tc3 = Timecode(24, '00:00:00:01')
+
+        self.assertTrue(tc1 == tc2)
+        self.assertTrue(tc1 >= tc2)
+        self.assertTrue(tc3 >= tc2)
+        self.assertFalse(tc2 >= tc3)
+
+    def test_le_overload(self):
+        tc1 = Timecode(24, '00:00:00:00')
+        tc2 = Timecode(24, '00:00:00:00')
+        tc3 = Timecode(24, '00:00:00:01')
+
+        self.assertTrue(tc1 == tc2)
+        self.assertTrue(tc1 <= tc2)
+        self.assertTrue(tc2 <= tc3)
+        self.assertFalse(tc2 >= tc3)
+
 
     # def test_exceptions(self):
     #     """test exceptions

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -717,13 +717,14 @@ class TimecodeTester(unittest.TestCase):
 
         tc = Timecode('23.98', '03:36:09:23')
         tc2 = Timecode('23.98', '00:00:29:23')
-        self.assertEqual(720, tc2.frames)
+        self.assertEqual(tc.frames, 311280)
+        self.assertEqual(tc2.frames, 720)
         d = tc * tc2
         f = tc * 720
-        self.assertEqual("04:09:35:23", d.__str__())
         self.assertEqual(224121600, d.frames)
-        self.assertEqual("04:09:35:23", f.__str__())
+        self.assertEqual("01:59:59:23", d.__str__())
         self.assertEqual(224121600, f.frames)
+        self.assertEqual("01:59:59:23", f.__str__())
 
         tc = Timecode('ms', '03:36:09.230')
         tc2 = Timecode('ms', '01:06:09.230')

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -48,7 +48,7 @@ class Timecode(object):
           of '00:00:00:00' will be used.
           When using 'ms' frame rate, timecodes like '00:11:01.040' use '.040'
           as frame number. When used with other frame rates, '.040' represents
-          a fraction of a second. So '00:00:00.040'@24fps is 1 frame.
+          a fraction of a second. So '00:00:00.040'@25fps is 1 frame.
         :type framerate: str or int or float
         :type start_timecode: str or None
         :param start_seconds: A float or integer value showing the seconds.

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 
 class Timecode(object):

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -119,7 +119,7 @@ class Timecode(object):
         elif framerate == 'frames':
             self._int_framerate = 1
         else:
-            self._int_framerate = int(framerate)
+            self._int_framerate = int(float(framerate))
 
         self._framerate = framerate
 

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -36,7 +36,8 @@ class Timecode(object):
 
         :param framerate: The frame rate of the Timecode instance. It
           should be one of ['23.98', '24', '25', '29.97', '30', '50', '59.94',
-          '60', 'ms'] where "ms" equals to 1000 fps. Can not be skipped.
+          '60', 'NUMERATOR/DENOMINATOR', ms'] where "ms" equals to 1000 fps.
+          Can not be skipped.
           Setting the framerate will automatically set the :attr:`.drop_frame`
           attribute to correct value.
         :param start_timecode: The start timecode. Use this to be able to
@@ -85,6 +86,11 @@ class Timecode(object):
         :param framerate:
         :return:
         """
+
+        # Convert rational framerate to float
+        if isinstance(framerate, basestring) and '/' in framerate:
+            numerator, denominator = framerate.split('/')
+            framerate = round(float(numerator) / float(denominator), 2)
 
         # check if number is passed and if so convert it to a string
         if isinstance(framerate, (int, float)):

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '0.4.3'
+__version__ = '1.0.0'
 
 
 class Timecode(object):

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -46,6 +46,9 @@ class Timecode(object):
           skipped then the start_second attribute will define the start
           timecode, and if start_seconds is also skipped then the default value
           of '00:00:00:00' will be used.
+          When using 'ms' frame rate, timecodes like '00:11:01.040' use '.040'
+          as frame number. When used with other frame rates, '.040' represents
+          a fraction of a second. So '00:00:00.040'@24fps is 1 frame.
         :type framerate: str or int or float
         :type start_timecode: str or None
         :param start_seconds: A float or integer value showing the seconds.
@@ -116,7 +119,7 @@ class Timecode(object):
         elif framerate == 'frames':
             self._int_framerate = 1
         else:
-            self._int_framerate = int(float(framerate))
+            self._int_framerate = int(framerate)
 
         self._framerate = framerate
 

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 
 class Timecode(object):

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -210,7 +210,11 @@ class Timecode(object):
                 frame_number += drop_frames * 9 * d
 
         ifps = self._int_framerate
+
         frs = frame_number % ifps
+        if self.fraction_frame:
+            frs = int(str(frs / float(ifps))[2:])
+
         secs = (frame_number // ifps) % 60
         mins = ((frame_number // ifps) // 60) % 60
         hrs = (((frame_number // ifps) // 60) // 60)
@@ -243,7 +247,7 @@ class Timecode(object):
         if self.drop_frame:
             return ';'
 
-        elif self.ms_frame:
+        elif self.ms_frame or self.fraction_frame:
             return '.'
 
         else:


### PR DESCRIPTION
Hi!

I've added some features I felt was useful and one of them might cause backward compatibility issues. Hence the major version update.

New features include support for >= and <= comparison of time codes, rational frame rate like '24000/1001' and support for what I called "fractional frames" where '.nnn' in the frame field get interpreted as fractions of seconds when frame rate is other than 'ms'. This is the standard for FFMpeg and some other video tools.

The potential backwards compatibility breaker is that when using the fractional frames mentioned above the Timecode.frs property method returns a float rather than int. 
Since this is part of a new feature I don't think it should cause problems, but if a script expects an int and use the new feature it will cause issues.

I've added some tests for the new features and it passes all the old ones.