### PR TITLE
Added support for Binary Codec Decimal timecode 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,9 +7,9 @@ Changes
 
 * **New:** Support for passing "binary coded decimal" (BCD) integer to
   timecode argument as it's stored in certain formats like OpenEXR and DPX.
-  https://en.wikipedia.org/wiki/SMPTE_timecode
-  Useful for parsing timecode from metadata through OpenImageIO for instamce.
+  Useful for parsing timecode from metadata through OpenImageIO for instance.
   Example: ``Timecode(24, 421729315) -> 19:23:14:23``
+  https://en.wikipedia.org/wiki/SMPTE_timecode
 
 1.0.0
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 =======
 Changes
 =======
+
+1.1.0
+=====
+
+* **New:** Support for passing "binary coded decimal" (BCD) integer to
+  timecode argument as it's stored in certain formats like OpenEXR and DPX.
+  https://en.wikipedia.org/wiki/SMPTE_timecode
+  Useful for parsing timecode from metadata through OpenImageIO for instamce.
+  Example: ``Timecode(24, 421729315) -> 19:23:14:23``
+
 1.0.0
 =====
 

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -45,6 +45,16 @@ class TimecodeTester(unittest.TestCase):
         Timecode('60')
         Timecode('ms')
 
+        Timecode('23.98', 421729315)
+        Timecode('24', 421729315)
+        Timecode('25', 421729315)
+        Timecode('29.97', 421729315)
+        Timecode('30', 421729315)
+        Timecode('50', 421729315)
+        Timecode('59.94', 421729315)
+        Timecode('60', 421729315)
+        Timecode('ms', 421729315)
+
         Timecode('24000/1000', '00:00:00:00')
         Timecode('24000/1001', '00:00:00;00')
         Timecode('30000/1000', '00:00:00:00')
@@ -74,14 +84,6 @@ class TimecodeTester(unittest.TestCase):
         Timecode(60)
         Timecode(1000)
         Timecode(24, frames=12000)
-
-        Timecode(24.0)
-        Timecode(25.0)
-        Timecode(30.0)
-        Timecode(50.0)
-        Timecode(60.0)
-        Timecode(1000.0)
-        Timecode(24.0, frames=12000)
 
     def test_repr_overload(self):
         timeobj = Timecode('24', '01:00:00:00')
@@ -171,6 +173,13 @@ class TimecodeTester(unittest.TestCase):
 
         tc = Timecode('59.94', frames=5178817)
         self.assertEqual('00:00:00;00', tc.__str__())
+
+        tc = Timecode('25', 421729315)
+        self.assertEqual('19:23:14:23', tc.__str__())
+
+        tc = Timecode('29.97', 421729315)
+        self.assertEqual('19:23:14;23', tc.__str__())
+        self.assertTrue(tc.drop_frame)
 
     def test_frame_to_tc(self):
         tc = Timecode('29.97', '00:00:00;01')

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 
 class Timecode(object):

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -140,6 +140,13 @@ class Timecode(object):
                                               self.parse_timecode(timecode)
                                               )
 
+        if isinstance(timecode, int):
+            time_tokens = [hours, minutes, seconds, frames]
+            timecode = ':'.join(str(t) for t in time_tokens)
+
+            if self.drop_frame:
+                timecode = ';'.join(timecode.rsplit(':', 1))
+
         ffps = float(self._framerate)
 
         if self.drop_frame:
@@ -255,11 +262,16 @@ class Timecode(object):
         """parses timecode string NDF '00:00:00:00' or DF '00:00:00;00' or
         milliseconds/fractionofseconds '00:00:00.000'
         """
-        bfr = timecode.replace(';', ':').replace('.', ':').split(':')
-        hrs = int(bfr[0])
-        mins = int(bfr[1])
-        secs = int(bfr[2])
-        frs = int(bfr[3])
+        if isinstance(timecode, int):
+            indices = range(2, 10, 2)
+            hrs, mins, secs, frs = [hex(timecode)[i:i + 2] for i in indices]
+
+        else:
+            bfr = timecode.replace(';', ':').replace('.', ':').split(':')
+            hrs = int(bfr[0])
+            mins = int(bfr[1])
+            secs = int(bfr[2])
+            frs = int(bfr[3])
 
         return hrs, mins, secs, frs
 


### PR DESCRIPTION
Hi!

I added another feature to the library. When reading time code from metadata through OpenImageIO you get a huge integer that doesn't seem to make sense but in reality is a Binary Coded Decimal (BCD) which is how time codes are stored in some file types. https://en.wikipedia.org/wiki/SMPTE_timecode

Also added some tests and suggested minor version bump. 
