### PR TITLE
Added some features and updated README, suggested minor version bump 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,18 @@
 Changes
 =======
 
+1.2.0
+=====
+* **NEW:** Support for passing a tuple with numerator and denominator when
+  passing rational framerate.
+
+* **NEW:** set_fractional method for setting whether or not to represent a
+  timecode as fractional seconds.
+
+* **Update:** Updated READEME's with info on new features
+
+* **FIX:** Some merge issues.
+
 1.1.0
 =====
 

--- a/README
+++ b/README
@@ -18,7 +18,7 @@ with an integer value or with a timecode is possible. Math operations between
 timecodes with different frame rates are supported. So::
 
     from timecode import Timecode
-  
+
     tc1 = Timecode('29.97', '00:00:00:00')
     tc2 = Timecode('24', '00:00:00:10')
     tc3 = tc1 + tc2
@@ -38,6 +38,28 @@ Use the ``frame_number`` attribute if you want to get a 0 based frame number::
 
 Frame rates 29.97 and 59.94 are always drop frame, and all the others are non
 drop frame.
+
+The timecode library supports rational frame rates passed as a string::
+
+    tc5 = Timecode('30000/1001', '00:00:00;00')
+    assert tc5.framerate == '29.97'
+
+You may also pass a big "Binary Coded Decimal" integer as start timecode::
+
+    tc6 = Timecode('24', 421729315)
+    assert repr(tc6) == '19:23:14:23'
+
+This is useful for parsing time codes stored in OpenEXR's and extracted through
+OpenImageIO for instance.
+
+Timecode also supports passing start timecodes formatted like HH:MM:SS.sss where
+SS.sss is seconds and fractions of seconds::
+
+    tc7 = Timecode(25, '00:00:00.040')
+    assert tc7.frame_number == 1
+
+This is useful when working with tools like FFMpeg.
+
 
 The SMPTE standard limits the timecode with 24 hours. Even though, Timecode
 instance will show the current timecode inline with the SMPTE standard, it will

--- a/README
+++ b/README
@@ -39,26 +39,38 @@ Use the ``frame_number`` attribute if you want to get a 0 based frame number::
 Frame rates 29.97 and 59.94 are always drop frame, and all the others are non
 drop frame.
 
-The timecode library supports rational frame rates passed as a string::
+The timecode library supports rational frame rates passed as a either a string
+ or tuple::
 
     tc5 = Timecode('30000/1001', '00:00:00;00')
     assert tc5.framerate == '29.97'
 
+    tc6 = Timecode((30000, 1001), '00:00:00;00')
+    assert tc6.framerate == '29.97'
+
 You may also pass a big "Binary Coded Decimal" integer as start timecode::
 
-    tc6 = Timecode('24', 421729315)
-    assert repr(tc6) == '19:23:14:23'
+    tc7 = Timecode('24', 421729315)
+    assert repr(tc7) == '19:23:14:23'
 
-This is useful for parsing time codes stored in OpenEXR's and extracted through
+This is useful for parsing timecodes stored in OpenEXR's and extracted through
 OpenImageIO for instance.
 
 Timecode also supports passing start timecodes formatted like HH:MM:SS.sss where
 SS.sss is seconds and fractions of seconds::
 
-    tc7 = Timecode(25, '00:00:00.040')
-    assert tc7.frame_number == 1
+    tc8 = Timecode(25, '00:00:00.040')
+    assert tc8.frame_number == 1
 
-This is useful when working with tools like FFMpeg.
+You may set any timecode to be represented as fractions of seconds::
+
+    tc9 = Timecode(24, '19:23:14:23')
+    assert repr(tc9) == '19:23:14:23'
+
+    tc9.set_fractional(True)
+    assert repr(tc9) == '19:23:14.958'
+
+Fraction of seconds is useful when working with tools like FFmpeg.
 
 
 The SMPTE standard limits the timecode with 24 hours. Even though, Timecode

--- a/README.md
+++ b/README.md
@@ -47,15 +47,24 @@ You may also pass a big "Binary Coded Decimal" integer as start timecode:
     tc6 = Timecode('24', 421729315)
     assert repr(tc6) == '19:23:14:23'
 
-This is useful for parsing time codes stored in OpenEXR's and extracted through
+This is useful for parsing timecodes stored in OpenEXR's and extracted through
 OpenImageIO for instance.
 
 Timecode also supports passing start timecodes formatted like HH:MM:SS.sss where
-SS.sss is seconds and fractions of seconds. This is useful when working with
-tools like FFMpeg
+SS.sss is seconds and fractions of seconds:
 
-    tc7 = Timecode(25, '00:00:00.040')
-    assert tc7.frame_number == 1
+    tc8 = Timecode(25, '00:00:00.040')
+    assert tc8.frame_number == 1
+
+You may set any timecode to be represented as fractions of seconds:
+
+    tc9 = Timecode(24, '19:23:14:23')
+    assert repr(tc9) == '19:23:14:23'
+
+    tc9.set_fractional(True)
+    assert repr(tc9) == '19:23:14.958'
+
+Fraction of seconds is useful when working with tools like FFmpeg.
 
 
 The SMPTE standard limits the timecode with 24 hours. Even though, Timecode

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ with an integer value or with a timecode is possible. Math operations between
 timecodes with different frame rates are supported. So:
 
     from timecode import Timecode
-  
-    tc1 = Timecode('29.97', '00:00:00:00')
+
+    tc1 = Timecode('29.97', '00:00:00;00')
     tc2 = Timecode('24', '00:00:00:10')
     tc3 = tc1 + tc2
     assert tc3.framerate == '29.97'
@@ -36,6 +36,27 @@ Use the ``frame_number`` attribute if you want to get a 0 based frame number:
 
 Frame rates 29.97 and 59.94 are always drop frame, and all the others are non
 drop frame.
+
+The timecode library supports rational frame rates passed as a string:
+
+    tc5 = Timecode('30000/1001', '00:00:00;00')
+    assert tc5.framerate == '29.97'
+
+You may also pass a big "Binary Coded Decimal" integer as start timecode:
+
+    tc6 = Timecode('24', 421729315)
+    assert repr(tc6) == '19:23:14:23'
+
+This is useful for parsing time codes stored in OpenEXR's and extracted through
+OpenImageIO for instance.
+
+Timecode also supports passing start timecodes formatted like HH:MM:SS.sss where
+SS.sss is seconds and fractions of seconds. This is useful when working with
+tools like FFMpeg
+
+    tc7 = Timecode(25, '00:00:00.040')
+    assert tc7.frame_number == 1
+
 
 The SMPTE standard limits the timecode with 24 hours. Even though, Timecode
 instance will show the current timecode inline with the SMPTE standard, it will

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -62,6 +62,13 @@ class TimecodeTester(unittest.TestCase):
         Timecode('60000/1000', '00:00:00:00')
         Timecode('60000/1001', '00:00:00;00')
 
+        Timecode((24000, 1000), '00:00:00:00')
+        Timecode((24000, 1001), '00:00:00;00')
+        Timecode((30000, 1000), '00:00:00:00')
+        Timecode((30000, 1001), '00:00:00;00')
+        Timecode((60000, 1000), '00:00:00:00')
+        Timecode((60000, 1001), '00:00:00;00')
+
         Timecode(24, frames=12000)
         Timecode(23.98, '00:00:00:00')
         Timecode(24, '00:00:00:00')
@@ -186,7 +193,7 @@ class TimecodeTester(unittest.TestCase):
         parameters is zero.
         """
         with self.assertRaises(ValueError) as cm:
-            tc = Timecode('29.97', start_seconds=0)
+            Timecode('29.97', start_seconds=0)
 
         self.assertEqual(
             str(cm.exception),
@@ -927,6 +934,10 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(tc.framerate, '59.94')
         self.assertEqual(tc._int_framerate, 60)
 
+        tc = Timecode((60000, 1001), '00:00:00;00')
+        self.assertEqual(tc.framerate, '59.94')
+        self.assertEqual(tc._int_framerate, 60)
+
     def test_rational_frame_delimiter(self):
         tc = Timecode('24000/1000', frames=1)
         self.assertFalse(';' in tc.__repr__())
@@ -951,12 +962,15 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(tc1.frame_number, 40)
         self.assertEqual(tc2.frame_number, 1)
 
-        tc3 = Timecode(24, 421729315)
-        self.assertEqual(tc3.__repr__(), '19:23:14:23')
-        tc3.set_fractional(True)
-        self.assertEqual(tc3.__repr__(), '19:23:14.958')
-        tc3.set_fractional(False)
-        self.assertEqual(tc3.__repr__(), '19:23:14:23')
+    def test_toggle_fractional_frame(self):
+        tc = Timecode(24, 421729315)
+        self.assertEqual(tc.__repr__(), '19:23:14:23')
+
+        tc.set_fractional(True)
+        self.assertEqual(tc.__repr__(), '19:23:14.958')
+
+        tc.set_fractional(False)
+        self.assertEqual(tc.__repr__(), '19:23:14:23')
 
     def test_ge_overload(self):
         tc1 = Timecode(24, '00:00:00:00')

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -951,6 +951,13 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual(tc1.frame_number, 40)
         self.assertEqual(tc2.frame_number, 1)
 
+        tc3 = Timecode(24, 421729315)
+        self.assertEqual(tc3.__repr__(), '19:23:14:23')
+        tc3.set_fractional(True)
+        self.assertEqual(tc3.__repr__(), '19:23:14.958')
+        tc3.set_fractional(False)
+        self.assertEqual(tc3.__repr__(), '19:23:14:23')
+
     def test_ge_overload(self):
         tc1 = Timecode(24, '00:00:00:00')
         tc2 = Timecode(24, '00:00:00:00')

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -103,7 +103,7 @@ class Timecode(object):
 
         # check if number is passed and if so convert it to a string
         if isinstance(framerate, (int, float)):
-            framerate = str(round(framerate, 2))
+            framerate = str(framerate)
 
         # set the int_frame_rate
         if framerate == '29.97':
@@ -125,6 +125,12 @@ class Timecode(object):
             self._int_framerate = int(float(framerate))
 
         self._framerate = framerate
+
+    def set_fractional(self, state):
+        """Set or unset timecode to be represented with fractional seconds
+        :param bool state:
+        """
+        self.fraction_frame = state
 
     def set_timecode(self, timecode):
         """Sets the frames by using the given timecode

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'
 
 
 class Timecode(object):
@@ -47,7 +47,7 @@ class Timecode(object):
       When using 'ms' frame rate, timecodes like '00:11:01.040' use '.040'
       as frame number. When used with other frame rates, '.040' represents
       a fraction of a second. So '00:00:00.040'@25fps is 1 frame.
-    :type framerate: str or int or float
+    :type framerate: str or int or float or tuple
     :type start_timecode: str or None
     :param start_seconds: A float or integer value showing the seconds.
     :param int frames: Timecode objects can be initialized with an
@@ -94,8 +94,15 @@ class Timecode(object):
         """
 
         # Convert rational frame rate to float
+        numerator = None
+        denominator = None
         if isinstance(framerate, basestring) and '/' in framerate:
             numerator, denominator = framerate.split('/')
+
+        elif isinstance(framerate, tuple):
+            numerator, denominator = framerate
+
+        if numerator and denominator:
             framerate = round(float(numerator) / float(denominator), 2)
 
             if framerate.is_integer():
@@ -251,10 +258,10 @@ class Timecode(object):
 
     def tc_to_string(self, hrs, mins, secs, frs):
         if self.fraction_frame:
-            return "{hh:02d}:{mm:02d}:{ss:06.3f}" .format(hh=hrs,
-                                                          mm=mins,
-                                                          ss=secs + frs
-                                                          )
+            return "{hh:02d}:{mm:02d}:{ss:06.3f}".format(hh=hrs,
+                                                         mm=mins,
+                                                         ss=secs + frs
+                                                         )
 
         ff = "%02d"
         if self.ms_frame:

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 
 class Timecode(object):


### PR DESCRIPTION
Hi again!

Here are some more updates:
* set_fractional() method for toggling representing timecode as fractions of seconds
* support for passing tuple as framerate for rational framerates
* updated README's
* minor tweaks and docstring updates