### PR TITLE
Fix: NameError: global name 'basestring' is not defined (python 3)

### DIFF
--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -25,6 +25,12 @@
 __version__ = '1.1.0'
 
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 class Timecode(object):
     """The main timecode class.
 


### PR DESCRIPTION
from: https://github.com/amnong/easywebdav/issues/26

Fix a NameError exception occurred when using timecode package with a python 3.x (x>=5) interpreter.