### PR TITLE
Fix for issue #13 - 29.97 NDF and 59.94 NDF support

### DIFF
--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -159,13 +159,10 @@ class TimecodeTester(unittest.TestCase):
         tc = Timecode('29.97', '03:36:09;23')
         self.assertEqual(388704, tc.frames)
 
-        tc = Timecode('29.97', '03:36:09;23', force_non_drop_frame=True)
-        self.assertEqual(388704, tc.frames)
+        tc = Timecode('29.97', '03:36:09:23', force_non_drop_frame=True)
+        self.assertEqual(388705, tc.frames)
 
         tc = Timecode('29.97', '03:36:09;23')
-        self.assertEqual(388704, tc.frames)
-
-        tc = Timecode('29.97', '03:36:09;23', force_non_drop_frame=True)
         self.assertEqual(388704, tc.frames)
 
         tc = Timecode('30', '03:36:09:23')

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -202,7 +202,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual('00:00:00;00', tc.__str__())
 
         tc = Timecode('29.97', frames=2589409, force_non_drop_frame=True)
-        self.assertEqual('00:00:00;00', tc.__str__())
+        self.assertEqual('00:00:00:00', tc.__str__())
 
         tc = Timecode('59.94', frames=5178816)
         self.assertEqual('23:59:59;59', tc.__str__())
@@ -218,7 +218,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertTrue(tc.drop_frame)
 
         tc = Timecode('29.97', 421729315, force_non_drop_frame=True)
-        self.assertEqual('19:23:14;23', tc.__str__())
+        self.assertEqual('19:23:14:23', tc.__str__())
         self.assertTrue(tc.drop_frame)
 
     def test_start_seconds_argument_is_zero(self):
@@ -402,15 +402,13 @@ class TimecodeTester(unittest.TestCase):
         assert t == "03:36:11;23"
         assert tc.frames == 388764
 
-
-
         # tc = Timecode('29.97', '03:36:09;23', force_drop_frame_to=False)
         # assert tc == '03:36:09;23'
 
         # for x in range(60):
         #     t = tc.next()
         #     self.assertTrue(t)
-        
+
         # assert t == ''
         # assert tc.frames == 388764
 
@@ -1054,7 +1052,7 @@ class TimecodeTester(unittest.TestCase):
         tc3 = Timecode(24, '00:00:00:01')
         tc4 = Timecode(24, '00:00:01.100')
         tc5 = Timecode(24, '00:00:01.200')
- 
+
         self.assertTrue(tc1 == tc2)
         self.assertTrue(tc1 <= tc2)
         self.assertTrue(tc2 <= tc3)

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -217,10 +217,6 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual('19:23:14;23', tc.__str__())
         self.assertTrue(tc.drop_frame)
 
-        tc = Timecode('29.97', 421729315, force_non_drop_frame=True)
-        self.assertEqual('19:23:14:23', tc.__str__())
-        self.assertTrue(tc.drop_frame)
-
     def test_start_seconds_argument_is_zero(self):
         """testing if a ValueError will be raised when the start_seconds
         parameters is zero.

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -113,6 +113,9 @@ class TimecodeTester(unittest.TestCase):
         timeobj = Timecode('29.97', '00:09:00;00')
         self.assertEqual('00:08:59;28', timeobj.__repr__())
 
+        timeobj = Timecode('29.97', '00:09:00:00', force_non_drop_frame=True)
+        self.assertEqual('00:08:59:13', timeobj.__repr__())
+
         timeobj = Timecode('30', '00:10:00:00')
         self.assertEqual('00:10:00:00', timeobj.__repr__())
 
@@ -141,13 +144,28 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual('00:00:00;00', tc.__str__())
         self.assertEqual(1, tc.frames)
 
+        tc = Timecode('29.97', force_non_drop_frame=True)
+        self.assertEqual('00:00:00:00', tc.__str__())
+        self.assertEqual(1, tc.frames)
+
+        tc = Timecode('29.97', force_non_drop_frame=True)
+
         tc = Timecode('29.97', '00:00:00;01')
+        self.assertEqual(2, tc.frames)
+
+        tc = Timecode('29.97', '00:00:00:01', force_non_drop_frame=True)
         self.assertEqual(2, tc.frames)
 
         tc = Timecode('29.97', '03:36:09;23')
         self.assertEqual(388704, tc.frames)
 
+        tc = Timecode('29.97', '03:36:09;23', force_non_drop_frame=True)
+        self.assertEqual(388704, tc.frames)
+
         tc = Timecode('29.97', '03:36:09;23')
+        self.assertEqual(388704, tc.frames)
+
+        tc = Timecode('29.97', '03:36:09;23', force_non_drop_frame=True)
         self.assertEqual(388704, tc.frames)
 
         tc = Timecode('30', '03:36:09:23')
@@ -186,6 +204,9 @@ class TimecodeTester(unittest.TestCase):
         tc = Timecode('29.97', frames=2589409)
         self.assertEqual('00:00:00;00', tc.__str__())
 
+        tc = Timecode('29.97', frames=2589409, force_non_drop_frame=True)
+        self.assertEqual('00:00:00;00', tc.__str__())
+
         tc = Timecode('59.94', frames=5178816)
         self.assertEqual('23:59:59;59', tc.__str__())
 
@@ -196,6 +217,10 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual('19:23:14:23', tc.__str__())
 
         tc = Timecode('29.97', 421729315)
+        self.assertEqual('19:23:14;23', tc.__str__())
+        self.assertTrue(tc.drop_frame)
+
+        tc = Timecode('29.97', 421729315, force_non_drop_frame=True)
         self.assertEqual('19:23:14;23', tc.__str__())
         self.assertTrue(tc.drop_frame)
 
@@ -316,6 +341,10 @@ class TimecodeTester(unittest.TestCase):
         tc = Timecode('29.97', '23:59:59;29')
         self.assertEqual(2589408, tc.frames)
 
+    def test_force_drop_frame_to_false(self):
+        tc = Timecode('29.97', '01:00:00:00', force_non_drop_frame=True)
+        self.assertEqual('00:59:56:12', tc.__repr__())
+
     def test_drop_frame(self):
         tc = Timecode('29.97', '13:36:59;29')
         timecode = tc.next()
@@ -375,6 +404,18 @@ class TimecodeTester(unittest.TestCase):
 
         assert t == "03:36:11;23"
         assert tc.frames == 388764
+
+
+
+        # tc = Timecode('29.97', '03:36:09;23', force_drop_frame_to=False)
+        # assert tc == '03:36:09;23'
+
+        # for x in range(60):
+        #     t = tc.next()
+        #     self.assertTrue(t)
+        
+        # assert t == ''
+        # assert tc.frames == 388764
 
         tc = Timecode('29.97', '03:36:09;23')
         for x in range(60):

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -114,7 +114,7 @@ class TimecodeTester(unittest.TestCase):
         self.assertEqual('00:08:59;28', timeobj.__repr__())
 
         timeobj = Timecode('29.97', '00:09:00:00', force_non_drop_frame=True)
-        self.assertEqual('00:08:59:13', timeobj.__repr__())
+        self.assertEqual('00:08:59:14', timeobj.__repr__())
 
         timeobj = Timecode('30', '00:10:00:00')
         self.assertEqual('00:10:00:00', timeobj.__repr__())

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -20,17 +20,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from decimal import Decimal, ROUND_HALF_UP
 
 __version__ = '1.2.1'
-
-
-def school_math_round(num):
-    """
-    Try built in round(2.5) and then use this method instead... Why? Not sure,
-    but this is right, for the moment at least.
-    """
-    return int(Decimal(num).quantize(Decimal(1), rounding=ROUND_HALF_UP))
 
 
 class Timecode(object):
@@ -230,7 +221,7 @@ class Timecode(object):
             # FIXME: Not sure what to do when new frame number is fractional.
             #  Currently we're just flooring the result, but not sure what we
             #  should do yet. TBD.
-            frame_number = school_math_round(
+            frame_number = round(
                 frame_number * (float(self._framerate)/float(ifps)))
 
         frames = frame_number + 1

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -20,8 +20,18 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+import math
+from decimal import Decimal, ROUND_HALF_UP
 
 __version__ = '1.2.1'
+
+
+def school_math_round(num):
+    """
+    Try built in round(2.5) and then use this method instead... Why? Not sure,
+    but this is right, for the moment at least.
+    """
+    return int(Decimal(num).quantize(Decimal(1), rounding=ROUND_HALF_UP))
 
 
 class Timecode(object):
@@ -221,10 +231,11 @@ class Timecode(object):
             # FIXME: Not sure what to do when new frame number is fractional.
             #  Currently we're just flooring the result, but not sure what we
             #  should do yet. TBD.
-            frame_number = round(
-                frame_number * (float(self._framerate)/float(ifps)))
+            corrected_frame_number = frame_number * (ffps / float(ifps))
+            frames = math.ceil(corrected_frame_number) + 1
 
-        frames = frame_number + 1
+        else:
+            frames = frame_number + 1
 
         return frames
 

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -20,11 +20,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+from decimal import Decimal, ROUND_HALF_UP
 
 __version__ = '1.2.1'
 
-import math
+
+def school_math_round(num):
+    """
+    Try built in round(2.5) and then use this method instead... Why? Not sure,
+    but this is right, for the moment at least.
+    """
+    return int(Decimal(num).quantize(Decimal(1), rounding=ROUND_HALF_UP))
 
 
 class Timecode(object):
@@ -224,7 +230,7 @@ class Timecode(object):
             # FIXME: Not sure what to do when new frame number is fractional.
             #  Currently we're just flooring the result, but not sure what we
             #  should do yet. TBD.
-            frame_number = math.floor(
+            frame_number = school_math_round(
                 frame_number * (float(self._framerate)/float(ifps)))
 
         frames = frame_number + 1


### PR DESCRIPTION
Thanks to North Shore Automation (northshoreautomation.com) @jeff-vincent and myself were able to work on fixing issue #13. Specifically, Adding 29.97 NDF and 59.94 NDF support, and contribute it back to the community.

This required adding a `force_non_drop_frame=False` argument to the `Timecode` class. If True, uses Non-Dropframe calculation for 29.97 or 59.94 only. Has no meaning for any other framerate.

We created some test cases, but there could clearly be more, and we'd love a sanity check to confirm we go it right. An off by one frame error would be rather easy to make. We will be using this in production shortly, so we'll have more confidence in our fix shortly, but we wanted to make it available for review now.
