### PR TITLE
Remove restriction of start_seconds not being zero

### DIFF
--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -74,8 +74,8 @@ class Timecode(object):
             if frames is not None:  # because 0==False, and frames can be 0
                 self.frames = frames
             elif start_seconds is not None:
-                if start_seconds == 0:
-                    raise ValueError("``start_seconds`` argument can not be 0")
+                #if start_seconds == 0:
+                #    raise ValueError("``start_seconds`` argument can not be 0")
                 self.frames = self.float_to_tc(start_seconds)
             else:
                 # use default value of 00:00:00:00


### PR DESCRIPTION
This removes the restriction of having a 0 second timecode. Otherwise, there is no way to have something like 00:00:00,000 from seconds.