### PR TITLE
Revert "Added option to make the Timecode fractional from creation"

### DIFF
--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -67,13 +67,14 @@ class Timecode(object):
     """
 
     def __init__(self, framerate, start_timecode=None, start_seconds=None,
-                 frames=None, fractional=False, force_non_drop_frame=False):
+                 frames=None, force_non_drop_frame=False):
 
         self.force_non_drop_frame = force_non_drop_frame
+
         self.drop_frame = False
 
         self.ms_frame = False
-        self.fraction_frame = fractional
+        self.fraction_frame = False
         self._int_framerate = None
         self._framerate = None
         self.framerate = framerate
@@ -88,8 +89,8 @@ class Timecode(object):
             if frames is not None:  # because 0==False, and frames can be 0
                 self.frames = frames
             elif start_seconds is not None:
-                #if start_seconds == 0:
-                #    raise ValueError("``start_seconds`` argument can not be 0")
+                if start_seconds == 0:
+                    raise ValueError("``start_seconds`` argument can not be 0")
                 self.frames = self.float_to_tc(start_seconds)
             else:
                 # use default value of 00:00:00:00


### PR DESCRIPTION
Reverts eoyilmaz/timecode#24

I had to revert this because one of the commits are forcing the ``start_seconds`` option to be 0 and it is meaningless. A TimeCode can newer be 0 seconds in length. People mix the concept of TimeCode with something else. A TimeCode of 00:00:00:00 shows a single frame which can not correspond to 0 seconds length of duration. It is at least 1/FPS seconds in length.