### PR TITLE
fix class method call

### DIFF
--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -211,7 +211,7 @@ class Timecode(object):
         if isinstance(timecode, Timecode):
             return timecode.frames
 
-        hours, minutes, seconds, frames = map(int, self.parse_timecode(timecode))
+        hours, minutes, seconds, frames = map(int, Timecode.parse_timecode(timecode))
 
         if isinstance(timecode, int):
             time_tokens = [hours, minutes, seconds, frames]


### PR DESCRIPTION
Fix a potential issue that a class method (parse_timecode) referenced from an instance (self). Pytest passes. I found it when I attempted to write a child class from Timecode.