### PR TITLE
Add realtime and systemtime getters. Preserve flags with operators.

### DIFF
--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -652,6 +652,7 @@ class Timecode(object):
         """
         # duplicate current one
         tc = Timecode(self.framerate, frames=self.frames)
+        tc.drop_frame = self.drop_frame
 
         if isinstance(other, Timecode):
             tc.add_frames(other.frames)
@@ -685,8 +686,9 @@ class Timecode(object):
             raise TimecodeError(
                 "Type {} not supported for arithmetic.".format(other.__class__.__name__)
             )
-
-        return Timecode(self.framerate, frames=abs(subtracted_frames))
+        tc = Timecode(self.framerate, frames=abs(subtracted_frames))
+        tc.drop_frame = self.drop_frame
+        return tc
 
     def __mul__(self, other):
         """Return a new Timecode instance with multiplied value.
@@ -709,8 +711,9 @@ class Timecode(object):
             raise TimecodeError(
                 "Type {} not supported for arithmetic.".format(other.__class__.__name__)
             )
-
-        return Timecode(self.framerate, frames=multiplied_frames)
+        tc = Timecode(self.framerate, frames=multiplied_frames)
+        tc.drop_frame = self.drop_frame
+        return tc
 
     def __div__(self, other):
         """Return a new Timecode instance with divided value.

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -296,7 +296,7 @@ class Timecode(object):
 
         return frame_number + 1  # frames
 
-    def frames_to_tc(self, frames):
+    def frames_to_tc(self, frames, skip_rollover = False):
         """Convert frames back to timecode.
 
         Args:
@@ -328,7 +328,8 @@ class Timecode(object):
 
         # If frame_number is greater than 24 hrs, next operation will rollover
         # clock
-        frame_number %= frames_per_24_hours
+        if not skip_rollover:
+            frame_number %= frames_per_24_hours
 
         if self.drop_frame:
             d = frame_number // frames_per_10_minutes
@@ -385,7 +386,10 @@ class Timecode(object):
         Returns:
             str: The "system time" timestamp of the Timecode.
         """
-        hh, mm, ss, ff = self.frames_to_tc(self.frames + 1)
+        if self.ms_frame:
+            return self.float-(1e-3) if as_float else str(self)
+
+        hh, mm, ss, ff = self.frames_to_tc(self.frames + 1, skip_rollover=True)
         framerate = float(self.framerate) if self._ntsc_framerate else self._int_framerate
         ms = ff/framerate
         if as_float:
@@ -404,6 +408,9 @@ class Timecode(object):
         """
         #float property is in the video system time grid
         ts_float = self.float
+
+        if self.ms_frame:
+            return ts_float-(1e-3) if as_float else str(self)
 
         # "int_framerate" frames is one second in NTSC time 
         if self._ntsc_framerate:


### PR DESCRIPTION
The purpose of this MR is to add a mean to get the timestamps of a given SMPTE Timecode. Two timebases are considered:
- Video system time: `to_systemtime()`
- Real time: `to_realtime()`

NTSC framerates will return different values as the system time is not aligned to the wall-clock time. All others should return the exact same value.

DF 29.97:
```python
> tc = Timecode("29.97", '00:59:59;29')
> tc.to_systemtime()
'01:00:00.000'
> tc.to_realtime()
'00:59:59.996'
```

NDF 29.97:
```python
> tc = Timecode("29.97", '00:59:59:29', force_non_drop_frame=True)
> tc.to_systemtime()
'01:00:00.000'
> tc.to_realtime()
'01:00:03.600'
```

PAL 50:
```python
> tc = Timecode("50", '00:59:59:49')
> tc.to_systemtime()
'01:00:00.000'
> tc.to_realtime()
'01:00:00.000'
```
I did not implement setters as I don't think there's a meaningful usage or need to them.
Hopefully this may help others understand better Timecodes running at different rates and the relations to the wall-clock time.


The second commit is to preserve the drop frame flag on elementary operations.
```python3
> tc = Timecode(29.97, '00:00:00:00',  force_non_drop_frame=True)
> assert tc.drop_frame is False
> tc = tc + 1
> tc
'00:00:00:01' #before: '00:00:00;01'
> tc.drop_frame
False #before: True
```