### PR TITLE
Add type hints, and restrict package to 3.7+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 *.egg-info/*
 *.swp
+.venv/*
 docs/html/*
 docs/latex/*
 docs/doctrees/*

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,6 @@ setup(
     package_data={
         "timecode": ["py.typed"],
     },
+    python_requires=">=3.7",
     zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read_file(file_path):
     Returns:
         str: The file content.
     """
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         data = f.read()
     return data
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,8 @@ setup(
     keywords=['video', 'timecode', 'smpte'],
     packages=find_packages(),
     include_package_data=True,
+    package_data={
+        "timecode": ["py.typed"],
+    },
     zip_safe=True,
 )

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -66,10 +66,7 @@ class Timecode(object):
         force_non_drop_frame (bool): If True, uses Non-Dropframe calculation for 29.97
             or 59.94 only. Has no meaning for any other framerate. It is False by
             default.
-    """        
-    _framerate: Union[str, int, float, Fraction]
-    _int_framerate: int
-    _frames: int
+    """
 
     def __init__(
         self,
@@ -86,11 +83,10 @@ class Timecode(object):
 
         self.ms_frame = False
         self.fraction_frame = False
-        self._int_framerate = None  # type: ignore
-        self._framerate = None  # type: ignore
+        self._int_framerate : Union[None, int] = None
+        self._framerate : Union[None, str, int, float, Fraction] = None
         self.framerate = framerate  # type: ignore
-
-        self._frames = None  # type: ignore
+        self._frames : Union[None, int] = None
 
         # attribute override order
         # start_timecode > frames > start_seconds

--- a/timecode/__init__.py
+++ b/timecode/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 
 __name__ = "timecode"
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __description__ = "SMPTE Time Code Manipulation Library"
 __author__ = "Erkan Ozgur Yilmaz"
 __author_email__ = "eoyilmaz@gmail.com"


### PR DESCRIPTION
Fix for #53 

I've added type hints to the package, including a `py.typed` marker file for mypy. This requires python 3.7+ since type hints aren't available in python 2, but python 2 was end of life in 2020!

A few places to look closely at:
- `typing.Literal` isn't available until python 3.8, but it's a very useful type hint in this case since it allows us to overload `to_systemtime()` and `to_realtime()` to be specific about whether they output `float` or `str`! The workaround here is to handle the `typing.Literal` import error gracefully, and only attempt to do the overload if we're in python 3.8+. You'll see an if statement doing this at line 394 and 425.
- The sorting magic methods (`__gt__()`, `__ge__()`, `__lt__()`, and `__le__()`) now raise an exception when you try to compare to a non-compatible type. The old behavior was simply returning `None`, which doesn't seem to be in line with standard python types.

I've tested this code on Python 3.7 and Python 3.11. All unit tests pass in both, and mypy works well in both. Pyright/Pylance in VS code also seems happy with these type hints.