### PR TITLE
[#70] Updated requirements to include `typing_extensions` for Python …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .coverage
 .DS_Store
+.env
 .pytest_cache/*
 .ruff_cache/*
 .venv/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+typing_extensions; python_version < "3.11"

--- a/src/timecode/timecode.py
+++ b/src/timecode/timecode.py
@@ -4,22 +4,21 @@
 from __future__ import annotations
 
 import math
-import sys
 from contextlib import suppress
 from typing import TYPE_CHECKING, overload
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 with suppress(ImportError):
     from typing import Literal
 
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Iterator
     from fractions import Fraction
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 
 class Timecode:


### PR DESCRIPTION
…versions lower than 3.11.