### PR TITLE
Fix to_systemtime sub-second precision for non-standard NTSC rates

### DIFF
--- a/src/timecode/timecode.py
+++ b/src/timecode/timecode.py
@@ -422,10 +422,10 @@ class Timecode:
             return self.float - (1e-3) if as_float else str(self)
 
         hh, mm, ss, ff = self.frames_to_tc(self.frames + 1, skip_rollover=True)
-        framerate = (
-            float(self.framerate) if self._ntsc_framerate else self._int_framerate
-        )
-        ms = ff / framerate
+        # System time is in the integer frame grid, so always divide by _int_framerate.
+        # Using float(self.framerate) for NTSC rates gives wrong sub-second values
+        # because the stored string (e.g. "47.95") loses precision vs the true rate.
+        ms = ff / self._int_framerate
         if as_float:
             return hh * 3600 + mm * 60 + ss + ms
         return f"{hh:02d}:{mm:02d}:{ss:02d}.{round(ms * 1000):03d}"

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -1764,3 +1764,18 @@ def test_generalized_ntsc_rational_formats(rational_str, int_framerate, is_drop)
     assert tc._ntsc_framerate is True
     assert tc._int_framerate == int_framerate
     assert tc.drop_frame is is_drop
+
+
+def test_systemtime_subframe_ntsc():
+    """to_systemtime uses integer framerate for sub-second calculation.
+
+    Non-standard NTSC rates (e.g. 48000/1001) are stored as a rounded float
+    string ("47.95"), so dividing by float(framerate) gives wrong milliseconds
+    for frames mid-second. The integer framerate (48) must be used instead.
+    """
+    from fractions import Fraction
+    # Frame 24 of 48000/1001 fps is exactly half a second in system time (24/48)
+    tc = Timecode(Fraction(48000, 1001), frames=24)
+    assert tc._ntsc_framerate is True
+    assert tc._int_framerate == 48
+    assert tc.to_systemtime() == "00:00:00.500"


### PR DESCRIPTION
`to_systemtime` computes the sub-second portion of the timestamp by dividing the frame count within the current second by the framerate:

```python
hh, mm, ss, ff = self.frames_to_tc(self.frames + 1, skip_rollover=True)
framerate = float(self.framerate) if self._ntsc_framerate else self._int_framerate
ms = ff / framerate
```

For NTSC rates, `float(self.framerate)` is used, but `self.framerate` stores whatever string was passed in, or a float rounded to 2 decimal places. For a standard rate like 29.97 that's fine. For a non-standard NTSC multiple like 48000/1001 (≈47.952 fps), the setter stores `"47.95"`, so the divisor is `47.95` instead of the correct integer framerate `48`:

```python
tc = Timecode(Fraction(48000, 1001), frames=24)
tc.to_systemtime()  # "00:00:00.501" — wrong, should be "00:00:00.500"
#                        ^^^
# 24 / 47.95 = 0.50052 → rounds to 501 ms
# 24 / 48    = 0.5     → rounds to 500 ms
```

All `to_systemtime` tests assert on whole-second boundaries, where `ff = 0` and therefore `ms = 0 / anything = 0`, so the divisor never mattered. The rounding error for standard rates (29.97, 59.94, 119.88) is also small enough (1ms per frame) that it happens to survive the 3-decimal string format for the values tested.

System time is defined in the integer frame grid. The divisor should always be `_int_framerate`:

```python
ms = ff / self._int_framerate
```

@cubicibo fixed this as part of #69. Parting it out for easier review.